### PR TITLE
Use the last directory of the vivado install path for the version check

### DIFF
--- a/Vivado/build.tcl
+++ b/Vivado/build.tcl
@@ -5,7 +5,7 @@
 
 # Check the version of Vivado used
 set version_required "2018.2"
-set ver [lindex [split $::env(XILINX_VIVADO) /] 3]
+set ver [lindex [split $::env(XILINX_VIVADO) /] end]
 if {![string equal $ver $version_required]} {
   puts "###############################"
   puts "### Failed to build project ###"


### PR DESCRIPTION
Replaces the hard-coded constant '3' with the last item of the splitted path in the version check comparison at the start of the script that builds the Vivado project.

This makes the script work correctly when Vivado is installed in a path that is more or less than 3 directories deep, i.e /opt/Xilinx/Vivado/2018.2/